### PR TITLE
Use a fake serial port instead of mocking api functions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
 
 [testenv:py37]
 commands = 
-    pytest --cov=tmv71
+    pytest --cov=tmv71 {posargs}
 
 [pytest]
 filterwarnings =


### PR DESCRIPTION
Instead of mocking out write_bytes, read_bytes, and read_line, we use
a fake serial port implementation that uses a pair of io.BytesIO
objects. This means we're actually running the send_bytes, etc,
methods, rather than excluding them from testing via mocks.